### PR TITLE
search bugfix

### DIFF
--- a/source/scss/views/page/search.scss
+++ b/source/scss/views/page/search.scss
@@ -7,7 +7,7 @@
     font-size: 24px;
 
     @keyframes loader {
-        from { transform: translate(-50%, -50%) rotate(0) },
+        from { transform: translate(-50%, -50%) rotate(0) }
         to { transform: translate(-50%, -50%) rotate(360deg) }
     }
 


### PR DESCRIPTION
Error: Invalid CSS after "...0%) rotate(0) }": expected selector, was ","
ERROR Asset render failed: scss/views/page/search.css
Error: Invalid CSS after "...0%) rotate(0) }": expected selector, was ","