### PR TITLE
update url of busuanzi.js and add total visit statistics

### DIFF
--- a/layout/_partial/common/footer.swig
+++ b/layout/_partial/common/footer.swig
@@ -52,6 +52,9 @@
                 <a href="https://github.com/Mrminfive/hexo-theme-skapp" target="_blank">Skapp</a> 2017 powered by
                 <a href="http://hexo.io/" target="_blank">Hexo</a>, made by 
                 <a href="https://github.com/Mrminfive" target="_blank">minfive</a>.
+                {% if config.busuanzi %}
+                <span id="busuanzi_container_site_pv">Total number of visits：<span id="busuanzi_value_site_pv"></span></span>&nbsp;Total visitor number:<span id="busuanzi_value_site_uv"></span>
+                {% endif %}
             </p>
             <ul class="footer__social-network clearfix">
                 {% if site.data.contact %}

--- a/layout/_partial/post/post-statistical.swig
+++ b/layout/_partial/post/post-statistical.swig
@@ -1,4 +1,4 @@
 <!-- 不蒜子统计 -->
 
-<script async src="//dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js">
+<script async src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js">
 </script>


### PR DESCRIPTION
卜蒜子的js  url修改，原先的域名不能用了
见http://busuanzi.ibruce.info/    “因七牛强制过期『dn-lbstatics.qbox.me』域名，与客服沟通无果，只能更换域名到『busuanzi.ibruce.info』！”